### PR TITLE
Add JWT validity to /recipe/jwt POST

### DIFF
--- a/api_spec.yaml
+++ b/api_spec.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   description: This version has not been released yet. Core Driver Interface http requests-responses
-  version: 2.8.0
+  version: 2.9.0
   title: Core Driver Interface
   contact:
     email: team@supertokens.io
@@ -839,7 +839,59 @@ paths:
         '500':
           $ref: '#/components/responses/500'
           
-  
+  /recipe/jwt:
+    post:
+      tags:
+        - JWT Recipe
+      operationId: createSignedJWT
+      description: |
+        Create a signed JWT
+      parameters:
+        - $ref: '#/components/parameters/jwtRID'
+        - $ref: '#/components/parameters/api-key'
+        - $ref: '#/components/parameters/cdi-version'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/createJWTRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/createSignedJWT'
+          
+        '400':
+          $ref: '#/components/responses/400'
+        
+        '404':
+          $ref: '#/components/responses/404'
+        
+        '500':
+          $ref: '#/components/responses/500'
+
+  /recipe/jwt/jwks:
+    get:
+      tags:
+        - JWT Recipe
+      description: |
+        Retrieve JWKs for JWT verification
+      parameters:
+        - $ref: '#/components/parameters/jwtRID'
+        - $ref: '#/components/parameters/api-key'
+        - $ref: '#/components/parameters/cdi-version'
+      responses:
+        '200':
+          $ref: '#/components/responses/getJWKS'
+          
+        '400':
+          $ref: '#/components/responses/400'
+        
+        '404':
+          $ref: '#/components/responses/404'
+        
+        '500':
+          $ref: '#/components/responses/500'
+
+
   /recipe/jwt/data:
     get:
       deprecated: true
@@ -1199,13 +1251,21 @@ components:
       required: true
       schema:
         type: string
+
+    jwtRID:
+      name: rid
+      in: header
+      example: jwt
+      required: true
+      schema:
+        type: string
         
         
     cdi-version:
       name: cdi-version
       in: header
       description: X.Y of the X.Y.Z CDI version. 
-      example: 2.8
+      example: 2.9
       required: true
       schema:
         type: string
@@ -1565,6 +1625,22 @@ components:
             oneOf:
               - $ref: '#/components/schemas/getSessionInfoResponse'
               - $ref: '#/components/schemas/unauthorisedMessageResponse'
+
+    createSignedJWT:
+      description: Create a signed JWT
+      content:
+        application/json:
+          schema:
+            oneOf:
+              - $ref: '#/components/schemas/createJWTResponse'
+              - $ref: '#/components/schemas/createJWTErrorResponse'
+    
+    getJWKS:
+      description: Retrieve JWKs for JWT verification
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/getJWKSResponse'
       
 
   schemas:
@@ -1711,6 +1787,16 @@ components:
           $ref: '#/components/schemas/handle'
         userDataInJWT:
           $ref: '#/components/schemas/userDataInJWT'
+
+    createJWTRequest:
+      type: object
+      properties:
+        payload:
+          $ref: '#/components/schemas/createJWTPayload'
+        algorithm:
+          $ref: '#/components/schemas/createJWTAlgorithm'
+        jwksDomain:
+          $ref: '#/components/schemas/jwksDomain'
 
     
     emailVerificationVerifyGetResponse:
@@ -1866,6 +1952,42 @@ components:
       type: array
       items:
         $ref: '#/components/schemas/handle'
+
+    createJWTPayload:
+      type: object
+      description: The payload of the JWT, should be a JSON object.
+      example: {"custom-claim": ""}
+
+    createJWTAlgorithm:
+      type: string
+      description: The algorithm to use when creating the JWT.
+      enum: ["RSA256"]
+
+    jwksDomain:
+      type: string
+      description: This is used as the value for the issuer claim in the JWT payload.
+      example: https://api.test.com/
+
+    jwk:
+      type: object
+      description: A JWK that can be used to verify a JWT
+      properties:
+        alg:
+          $ref: '#/components/schemas/createJWTAlgorithm'
+        kty:
+          type: string
+          example: RSA
+        use:
+          type: string
+          example: sig
+        kid:
+          type: string
+          description: Unique identifier for the JWK
+        x5c:
+          type: array
+          description: X.509 Certificate Chain
+          items:
+            type: string
         
       
         
@@ -2171,7 +2293,7 @@ components:
           type: array
           items:
             type: string
-            example: ['2.8']
+            example: ['2.9']
     
     usersResponse:
       type: object
@@ -2306,6 +2428,30 @@ components:
         status:
           type: string
           enum: ['UNKNOWN_USER_ID_ERROR', 'UNKNOWN_EMAIL_ERROR']
+
+    createJWTResponse:
+      type: object
+      properties:
+        status:
+          $ref: '#/components/schemas/statusOK'
+        jwt:
+          type: string
+          example: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c
+
+    createJWTErrorResponse:
+      type: object
+      properties:
+        status:
+          type: string
+          enum: ['UNSUPPORTED_ALGORITHM_ERROR', 'JWT_CREATION_ERROR']
+
+    getJWKSResponse:
+      type: object
+      properties:
+        keys:
+          type: array
+          items: 
+            $ref: '#/components/schemas/jwk'
     
     
     

--- a/api_spec.yaml
+++ b/api_spec.yaml
@@ -1920,6 +1920,9 @@ components:
           $ref: '#/components/schemas/createJWTAlgorithm'
         jwksDomain:
           $ref: '#/components/schemas/jwksDomain'
+        validity:
+          $ref: '#/components/schemas/jwtValidity'
+
 
     
     emailVerificationVerifyGetResponse:
@@ -2090,6 +2093,10 @@ components:
       type: string
       description: This is used as the value for the issuer claim in the JWT payload.
       example: https://api.test.com/
+    jwtValidity:
+      type: number
+      description: Duration in seconds, used to calculate JWT expiry
+      example: 86400
 
     jwk:
       type: object


### PR DESCRIPTION
When creating JWTs the user should be able to configure how long the JWT would be valid for. We will have default values (configured in the backend SDK as a config option when initialising the JWT recipe) and the user will have the option to pass a custom value when creating JWTs as well.

To reflect that change in the core's APIs, the CDI spec for `/recipe/jwt POST` now has a new parameter in the request body called `validity` which is a number value for the duration (in seconds) for how long the JWT will be valid. The core will use `currentTime + validity` to calculate the JWT expiry when creating it