### PR TITLE
feat: access token to jwt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## [2.19.0] - XXX
+
+- deprecate jwks endpoint in the jwt recipe (GET `/recipe/jwt/jwks`)
+- add standard jwks endpoint (GET `/.well-known/jwks.json`)
+- add `useStaticSigningKey` into `createNewSession` (POST `/recipe/session`). This will be used instead of `access_token_signing_key_dynamic`
+- add `useStaticSigningKey` into `createSignedJWT` (POST `/recipe/jwt`).
+- removed handshake endpoint (POST `/recipe/handshake`)
+- add checkDatabase into `verifySession` (POST `/recipe/session/verify`)
+- removed old/unused props from responses related to signing keys & `id-refresh-token`
+
 ## [2.18.1] - 2023-03-1
 
 ### Fixed 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
-## Unreleased 
+## [2.21.0] - 2023-04-05
 
 - deprecate jwks endpoint in the jwt recipe (GET `/recipe/jwt/jwks`)
 - add standard jwks endpoint (GET `/.well-known/jwks.json`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - deprecate jwks endpoint in the jwt recipe (GET `/recipe/jwt/jwks`)
 - add standard jwks endpoint (GET `/.well-known/jwks.json`)
-- add `useStaticSigningKey` into `createNewSession` (POST `/recipe/session`). This will be used instead of `access_token_signing_key_dynamic`
+- add `useDynamicSigningKey` into `createNewSession` (POST `/recipe/session`). This will be used instead of `access_token_signing_key_dynamic`
 - add `useStaticSigningKey` into `createSignedJWT` (POST `/recipe/jwt`).
 - removed handshake endpoint (POST `/recipe/handshake`)
 - add checkDatabase into `verifySession` (POST `/recipe/session/verify`)

--- a/api_spec.yaml
+++ b/api_spec.yaml
@@ -2828,7 +2828,7 @@ paths:
   /.well-known/jwks.json:
     get:
       tags:
-        - JWT Recipe
+        - Core
       description: |
         Retrieve JWKs for JWT verification
       responses:

--- a/api_spec.yaml
+++ b/api_spec.yaml
@@ -2259,9 +2259,9 @@ paths:
                   $ref: '#/components/schemas/userDataInDatabase'
                 enableAntiCsrf:
                   $ref: '#/components/schemas/enableAntiCsrf'
-                useStaticSigningKey:
+                useDynamicSigningKey:
                   type: boolean
-                  description: Decides if the token should be signed with a dynamic or static key, defaults to false
+                  description: Decides if the token should be signed with a dynamic or static key, defaults to true
                   example: false
       responses:
         '200':

--- a/api_spec.yaml
+++ b/api_spec.yaml
@@ -2789,6 +2789,42 @@ paths:
         '500':
           $ref: '#/components/responses/500'
 
+  /recipe/jwt/jwks:
+    get:
+      deprecated: true
+      tags:
+        - JWT Recipe
+      description: |
+        Retrieve JWKs for JWT verification
+      parameters:
+        - $ref: '#/components/parameters/jwtRID'
+        - $ref: '#/components/parameters/api-key'
+        - $ref: '#/components/parameters/cdi-version'
+      responses:
+        '200':
+          description: Retrieve JWKs for JWT verification
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum: ["OK"]
+                  keys:
+                    type: array
+                    items: 
+                      $ref: '#/components/schemas/jwk'
+          
+        '400':
+          $ref: '#/components/responses/400'
+        
+        '404':
+          $ref: '#/components/responses/404'
+        
+        '500':
+          $ref: '#/components/responses/500'
+
   /.well-known/jwks.json:
     get:
       tags:

--- a/api_spec.yaml
+++ b/api_spec.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   description: This is the API exposed by the SuperTokens Core. To be consumed by your backend only.
-  version: 2.17.0
+  version: 2.18.0
   title: Core Driver Interface
   contact:
     email: team@supertokens.io
@@ -1660,12 +1660,6 @@ paths:
                   properties:
                     status:
                       $ref: '#/components/schemas/statusOK'
-                    jwtSigningPublicKey:
-                      $ref: '#/components/schemas/jwtSigningPublicKey'
-                    jwtSigningPublicKeyExpiryTime:
-                      $ref: '#/components/schemas/jwtSigningPublicKeyExpiryTime'
-                    jwtSigningPublicKeyList:
-                      $ref: '#/components/schemas/jwtSigningPublicKeyList'
                     accessTokenBlacklistingEnabled:
                       $ref: '#/components/schemas/accessTokenBlacklistingEnabled'
                     accessTokenValidity:
@@ -2302,6 +2296,8 @@ paths:
                   $ref: '#/components/schemas/userDataInDatabase'
                 enableAntiCsrf:
                   $ref: '#/components/schemas/enableAntiCsrf'
+                useStaticSigningKey:
+                  $ref: '#/components/schemas/useStaticSigningKey'
       responses:
         '200':
           description: Create a new Session
@@ -2318,16 +2314,8 @@ paths:
                       $ref: '#/components/schemas/cookieInfo'
                     refreshToken:
                       $ref: '#/components/schemas/cookieInfo'
-                    idRefreshToken:
-                      $ref: '#/components/schemas/cookieInfo'
                     antiCsrfToken:
                       $ref: '#/components/schemas/token'
-                    jwtSigningPublicKey:
-                      $ref: '#/components/schemas/jwtSigningPublicKey'
-                    jwtSigningPublicKeyExpiryTime:
-                      $ref: '#/components/schemas/jwtSigningPublicKeyExpiryTime'
-                    jwtSigningPublicKeyList:
-                      $ref: '#/components/schemas/jwtSigningPublicKeyList'
           
         '400':
           $ref: '#/components/responses/400'
@@ -2482,23 +2470,11 @@ paths:
                           $ref: '#/components/schemas/session'
                         accessToken:
                           $ref: '#/components/schemas/cookieInfo'
-                        jwtSigningPublicKey:
-                          $ref: '#/components/schemas/jwtSigningPublicKey'
-                        jwtSigningPublicKeyExpiryTime:
-                          $ref: '#/components/schemas/jwtSigningPublicKeyExpiryTime'
-                        jwtSigningPublicKeyList:
-                          $ref: '#/components/schemas/jwtSigningPublicKeyList'
                     - $ref: '#/components/schemas/unauthorisedMessageResponse'
                     - type: object
                       properties:
                         status:
                           $ref: '#/components/schemas/tryRefreshTokenResponse'
-                        jwtSigningPublicKey:
-                          $ref: '#/components/schemas/jwtSigningPublicKey'
-                        jwtSigningPublicKeyExpiryTime:
-                          $ref: '#/components/schemas/jwtSigningPublicKeyExpiryTime'
-                        jwtSigningPublicKeyList:
-                          $ref: '#/components/schemas/jwtSigningPublicKeyList'
                         message:
                           $ref: '#/components/schemas/message'
           
@@ -2555,8 +2531,6 @@ paths:
                         accessToken:
                           $ref: '#/components/schemas/cookieInfo'
                         refreshToken:
-                          $ref: '#/components/schemas/cookieInfo'
-                        idRefreshToken: 
                           $ref: '#/components/schemas/cookieInfo'
                         antiCsrfToken: 
                           $ref: '#/components/schemas/token'
@@ -2783,6 +2757,9 @@ paths:
                   $ref: '#/components/schemas/jwksDomain'
                 validity:
                   $ref: '#/components/schemas/jwtValidity'
+                useDynamicSigningKey:
+                  $ref: '#/components/schemas/useDynamicSigningKey'
+                  
       responses:
         '200':
           description: Create a signed JWT
@@ -2812,16 +2789,12 @@ paths:
         '500':
           $ref: '#/components/responses/500'
 
-  /recipe/jwt/jwks:
+  /.well-known/jwks.json:
     get:
       tags:
         - JWT Recipe
       description: |
         Retrieve JWKs for JWT verification
-      parameters:
-        - $ref: '#/components/parameters/jwtRID'
-        - $ref: '#/components/parameters/api-key'
-        - $ref: '#/components/parameters/cdi-version'
       responses:
         '200':
           description: Retrieve JWKs for JWT verification
@@ -2830,9 +2803,6 @@ paths:
               schema:
                 type: object
                 properties:
-                  status:
-                    type: string
-                    enum: ["OK"]
                   keys:
                     type: array
                     items: 
@@ -3743,30 +3713,6 @@ components:
       description: The maximum lifetime of the code in milliseconds
       example: 900000
 
-    jwtSigningPublicKey:
-      type: string
-      example: MIIBIjANBgkq...nKH0QIDAQAB
-    
-    jwtSigningPublicKeyCreatedAt:
-      type: number
-      example: 1624344236945
-
-    jwtSigningPublicKeyExpiryTime:
-      type: number
-      example: 1624345236945
-    
-    jwtSigningPublicKeyList:
-      type: array
-      items:
-        type: object
-        properties: 
-          publicKey:
-            $ref: '#/components/schemas/jwtSigningPublicKey'
-          createdAt:
-            $ref: '#/components/schemas/jwtSigningPublicKeyCreatedAt'
-          expiryTime:
-            $ref: '#/components/schemas/jwtSigningPublicKeyExpiryTime'
-
     accessTokenBlacklistingEnabled:
       type: boolean
       example: true
@@ -3868,7 +3814,14 @@ components:
       type: number
       description: Duration in seconds, used to calculate JWT expiry
       example: 86400
-
+    useDynamicSigningKey:
+      type: boolean
+      description: Decides if the token should be signed with a dynamic or static key
+      example: false
+    useStaticSigningKey:
+      type: boolean
+      description: Decides if the token should be signed with a dynamic or static key
+      example: false
     jwk:
       type: object
       description: A JWK that can be used to verify a JWT

--- a/api_spec.yaml
+++ b/api_spec.yaml
@@ -1637,46 +1637,6 @@ paths:
           $ref: '#/components/responses/404'
         
         '500':
-          $ref: '#/components/responses/500'  
-  
-  /recipe/handshake:
-    post:
-      tags: 
-        - Session Recipe
-      operationId: sessionHandshake
-      description: |
-        Handshake for session
-      parameters:
-        - $ref: '#/components/parameters/sessionRid'
-        - $ref: '#/components/parameters/api-key'
-        - $ref: '#/components/parameters/cdi-version'
-      responses:
-        '200':
-          description: Session Handshake
-          content:
-            application/json:
-                schema: 
-                  type: object
-                  properties:
-                    status:
-                      $ref: '#/components/schemas/statusOK'
-                    accessTokenBlacklistingEnabled:
-                      $ref: '#/components/schemas/accessTokenBlacklistingEnabled'
-                    accessTokenValidity:
-                      $ref: '#/components/schemas/accessTokenValidity'
-                    refreshTokenValidity: 
-                      $ref: '#/components/schemas/refreshTokenValidity'
-          
-        '400':
-          $ref: '#/components/responses/400'
-        
-        '401':
-          $ref: '#/components/responses/401'
-        
-        '404':
-          $ref: '#/components/responses/404'
-        
-        '500':
           $ref: '#/components/responses/500'
 
   /recipe/user/metadata:
@@ -2297,7 +2257,9 @@ paths:
                 enableAntiCsrf:
                   $ref: '#/components/schemas/enableAntiCsrf'
                 useStaticSigningKey:
-                  $ref: '#/components/schemas/useStaticSigningKey'
+                  type: boolean
+                  description: Decides if the token should be signed with a dynamic or static key, defaults to false
+                  example: false
       responses:
         '200':
           description: Create a new Session
@@ -2757,8 +2719,10 @@ paths:
                   $ref: '#/components/schemas/jwksDomain'
                 validity:
                   $ref: '#/components/schemas/jwtValidity'
-                useDynamicSigningKey:
-                  $ref: '#/components/schemas/useDynamicSigningKey'
+                useStaticSigningKey:
+                  type: boolean
+                  description: Decides if the token should be signed with a dynamic or static key, defaults to true
+                  example: true
                   
       responses:
         '200':
@@ -2795,14 +2759,14 @@ paths:
       tags:
         - JWT Recipe
       description: |
-        Retrieve JWKs for JWT verification
+        Retrieve JWKs for JWT verification, containing both static and dynamic keys.
       parameters:
         - $ref: '#/components/parameters/jwtRID'
         - $ref: '#/components/parameters/api-key'
         - $ref: '#/components/parameters/cdi-version'
       responses:
         '200':
-          description: Retrieve JWKs for JWT verification
+          description: Retrieve JWKs for JWT verification, containing both static and dynamic keys.
           content:
             application/json:
               schema:
@@ -2830,10 +2794,10 @@ paths:
       tags:
         - Core
       description: |
-        Retrieve JWKs for JWT verification
+        Retrieve JWKs for JWT verification, containing both static and dynamic keys.
       responses:
         '200':
-          description: Retrieve JWKs for JWT verification
+          description: Retrieve JWKs for JWT verification, containing both static and dynamic keys.
           content:
             application/json:
               schema:
@@ -3850,14 +3814,6 @@ components:
       type: number
       description: Duration in seconds, used to calculate JWT expiry
       example: 86400
-    useDynamicSigningKey:
-      type: boolean
-      description: Decides if the token should be signed with a dynamic or static key
-      example: false
-    useStaticSigningKey:
-      type: boolean
-      description: Decides if the token should be signed with a dynamic or static key
-      example: false
     jwk:
       type: object
       description: A JWK that can be used to verify a JWT

--- a/api_spec.yaml
+++ b/api_spec.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   description: This is the API exposed by the SuperTokens Core. To be consumed by your backend only.
-  version: 2.20.0
+  version: 2.21.0
   title: Core Driver Interface
   contact:
     email: team@supertokens.io

--- a/api_spec.yaml
+++ b/api_spec.yaml
@@ -3712,18 +3712,6 @@ components:
       type: number
       description: The maximum lifetime of the code in milliseconds
       example: 900000
-
-    accessTokenBlacklistingEnabled:
-      type: boolean
-      example: true
-      
-    accessTokenValidity:
-      type: number
-      example: 3600000
-    
-    refreshTokenValidity:
-      type: number
-      example: 8640000000
               
     statusOK:
       type: string

--- a/api_spec.yaml
+++ b/api_spec.yaml
@@ -2418,6 +2418,10 @@ paths:
                 doAntiCsrfCheck:
                   type: boolean
                   example: false
+                checkDatabase:
+                  type: boolean
+                  description: Decides if we always check if the session exists in the DB or just do token validation, defaults to false.
+                  example: false
                 antiCsrfToken:
                   $ref: '#/components/schemas/token'
       responses:


### PR DESCRIPTION
- deprecate jwks endpoint in the jwt recipe
- add standard jwks endpoint
- add `useStaticKey` into `createNewSession`. This can be used instead of `access_token_signing_key_dynamic`
- add `useDynamicKey` into `createSignedJWT`.
- removed old/unused props from responses related to signing keys & id-refresh-token