### PR TITLE
docs: removed default scopes addition in create client api

### DIFF
--- a/api_spec.yaml
+++ b/api_spec.yaml
@@ -832,9 +832,6 @@ paths:
                 name:
                   type: string
                   example: 'development'
-                addDefaultSupertokensScopes:
-                  type: boolean
-                  default: true
                 scopes:
                   type: array
                   items:


### PR DESCRIPTION
removed adding of default scopes on client creation, also on made changes to the flow diagram.